### PR TITLE
Upstream balenaOS patches

### DIFF
--- a/modules/rtc-unipi/rtc-unipi.c
+++ b/modules/rtc-unipi/rtc-unipi.c
@@ -677,7 +677,7 @@ read_rtc:
 	    rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
 #else
 	    nvmem_cfg.priv = rtc_unipi;
-	    rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
+	    devm_rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
 #endif
 	rtc_unipi->rtc->ops = &mcp794xx_rtc_ops; /*chip->rtc_ops ?: &ds13xx_rtc_ops;*/
 	err = rtc_register_device(rtc_unipi->rtc);

--- a/modules/rtc-unipi/rtc-unipi.c
+++ b/modules/rtc-unipi/rtc-unipi.c
@@ -680,7 +680,11 @@ read_rtc:
 	    devm_rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
 #endif
 	rtc_unipi->rtc->ops = &mcp794xx_rtc_ops; /*chip->rtc_ops ?: &ds13xx_rtc_ops;*/
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
 	err = rtc_register_device(rtc_unipi->rtc);
+#else
+	err = devm_rtc_register_device(rtc_unipi->rtc);
+#endif
 	if (err)
 		return err;
 

--- a/modules/rtc-unipi/rtc-unipi.c
+++ b/modules/rtc-unipi/rtc-unipi.c
@@ -671,11 +671,13 @@ read_rtc:
 
 		rtc_unipi->rtc->nvmem_config = &rtc_unipi->nvmem_cfg;
 		rtc_unipi->rtc->nvram_old_abi = true;
-#else
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
 		nvmem_cfg.priv = rtc_unipi;
 	    rtc_unipi->rtc->nvram_old_abi = true;
 	    rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
-
+#else
+	    nvmem_cfg.priv = rtc_unipi;
+	    rtc_nvmem_register(rtc_unipi->rtc, &nvmem_cfg);
 #endif
 	rtc_unipi->rtc->ops = &mcp794xx_rtc_ops; /*chip->rtc_ops ?: &ds13xx_rtc_ops;*/
 	err = rtc_register_device(rtc_unipi->rtc);

--- a/modules/unipi/src/unipi_spi.c
+++ b/modules/unipi/src/unipi_spi.c
@@ -329,7 +329,12 @@ struct unipi_spi_context* unipi_spi_setup_context(struct spi_device* spi_dev, st
     s_trans = (struct spi_transfer *)(context + 1);
     spi_message_init_with_transfers(&context->message, s_trans, trans_count);
 
-	s_trans[0].delay_usecs = NEURONSPI_EDGE_DELAY;
+#if  LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
+        s_trans[0].delay_usecs = NEURONSPI_EDGE_DELAY;
+#else
+        s_trans[0].delay.value = NEURONSPI_EDGE_DELAY;
+        s_trans[0].delay.unit = SPI_DELAY_UNIT_USECS;
+#endif
 	s_trans[0].bits_per_word = 8;
 	s_trans[0].speed_hz = freq;
 
@@ -341,7 +346,12 @@ struct unipi_spi_context* unipi_spi_setup_context(struct spi_device* spi_dev, st
             packet_crc = neuronspi_spi_crc(send_buf->first_message, 4, 0);
             *((u16*)(send_buf->first_message+4)) = packet_crc;
         }
+#if  LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
         s_trans[1].delay_usecs = delay;
+#else
+        s_trans[1].delay.value = delay;
+        s_trans[1].delay.unit = SPI_DELAY_UNIT_USECS;
+#endif
         s_trans[1].len = NEURONSPI_FIRST_MESSAGE_LENGTH;
         s_trans[1].tx_buf = send_buf->first_message;
         s_trans[1].rx_buf = recv_buf->first_message;
@@ -355,7 +365,12 @@ struct unipi_spi_context* unipi_spi_setup_context(struct spi_device* spi_dev, st
 		unipi_spi_trace_1(KERN_INFO "UNIPISPI: SPI Master Write(%3d) %32ph\n", len, send_buf->second_message);
 		remain = len;
 		for (i = 2; i < trans_count; i++) {
+#if  LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
 			s_trans[i].delay_usecs = 0;
+#else
+			s_trans[i].delay.value = 0;
+			s_trans[i].delay.unit = SPI_DELAY_UNIT_USECS;
+#endif
 			s_trans[i].bits_per_word = 8;
 			s_trans[i].speed_hz = freq;
 			s_trans[i].tx_buf = send_buf->second_message + (NEURONSPI_MAX_TX * (i - 2));

--- a/modules/unipi/src/unipi_spi.c
+++ b/modules/unipi/src/unipi_spi.c
@@ -1243,7 +1243,7 @@ s32 neuronspi_spi_probe(struct spi_device *spi)
 	u32 always_create_uart = 0;
     struct kthread_worker   *worker;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
     struct spi_delay inactive_delay;
 #endif
 
@@ -1373,7 +1373,7 @@ s32 neuronspi_spi_probe(struct spi_device *spi)
     if (gpio_is_valid(spi->cs_gpio)) {
         spi->cs_gpio = -spi->cs_gpio;
     }
-#else
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0) && LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
     inactive_delay.value = 40;
     inactive_delay.unit = SPI_DELAY_UNIT_USECS;
 	spi_set_cs_timing(spi, NULL, NULL, &inactive_delay);

--- a/modules/unipi/src/unipi_tty.c
+++ b/modules/unipi/src/unipi_tty.c
@@ -1019,7 +1019,11 @@ int __init unipi_tty_init(void)
 {
 	int err;
 	unipi_tty_trace(KERN_INFO "UNIPISPI: TTY Init\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 	err = tty_register_ldisc(N_PROFIBUS_FDL, &unipi_tty_ops);
+#else
+	err = tty_register_ldisc(&unipi_tty_ops);
+#endif
 	if (err) {
 		printk(KERN_INFO "UNIPISPI: UniPi line discipline registration failed. (%d)", err);
 		return err;
@@ -1029,7 +1033,11 @@ int __init unipi_tty_init(void)
 
 void __exit unipi_tty_exit(void)
 {
-     tty_unregister_ldisc(N_PROFIBUS_FDL);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
+    tty_unregister_ldisc(N_PROFIBUS_FDL);
+#else
+     tty_unregister_ldisc(&unipi_tty_ops);
+#endif
 }
 
 #else
@@ -1111,7 +1119,12 @@ int __init unipi_tty_init(void)
 	unipi_tty_ldisc.receive_buf2	= unipi_tty_receive_buf2;
 	unipi_tty_ldisc.ioctl	        = unipi_tty_ioctl;
 
-    err = tty_register_ldisc(N_PROFIBUS_FDL, &unipi_tty_ldisc);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
+   err = tty_register_ldisc(N_PROFIBUS_FDL, &unipi_tty_ldisc);
+#else
+    err = tty_register_ldisc(&unipi_tty_ldisc);
+#endif
     if (err) {
         printk(KERN_INFO "UniPi line discipline registration failed. (%d)", err);
         return err;
@@ -1121,6 +1134,10 @@ int __init unipi_tty_init(void)
 
 void __exit unipi_tty_exit(void)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
      tty_unregister_ldisc(N_PROFIBUS_FDL);
+#else
+     tty_unregister_ldisc(&unipi_tty_ldisc);
+#endif
 }
 #endif

--- a/modules/unipi/src/unipi_tty.c
+++ b/modules/unipi/src/unipi_tty.c
@@ -662,7 +662,12 @@ static int copy_from_read_buf(struct tty_struct *tty,
  */
 
 static ssize_t unipi_tty_read(struct tty_struct *tty, struct file *file,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
 			 unsigned char __user *buf, size_t nr)
+#else
+			 unsigned char *buf, size_t nr,
+			 void **cookie, unsigned long offset)
+#endif
 {
 	struct unipi_tty_data *ldata = tty->disc_data;
     struct tty_port *port = tty->port;

--- a/modules/unipi/src/unipi_tty.c
+++ b/modules/unipi/src/unipi_tty.c
@@ -1044,14 +1044,26 @@ void __exit unipi_tty_exit(void)
 
 struct tty_ldisc_ops unipi_tty_ldisc;
 static void (*alias_n_tty_receive_buf)(struct tty_struct *tty, const unsigned char *cp,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 			      char *fp, int count);
+#else
+			      const char *fp, int count);
+#endif
 static int (*alias_n_tty_receive_buf2)(struct tty_struct *tty, const unsigned char *cp,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 			      char *fp, int count);
+#else
+			      const char *fp, int count);
+#endif
 static int (*alias_n_tty_ioctl)(struct tty_struct *tty, struct file *file,
                unsigned int cmd, unsigned long arg);
 
 static void unipi_tty_receive_buf(struct tty_struct *tty, const unsigned char *cp,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 			      char *fp, int count)
+#else
+			      const char *fp, int count)
+#endif
 {
     int is_parmrk = I_PARMRK(tty);
     if (is_parmrk) {
@@ -1065,7 +1077,11 @@ static void unipi_tty_receive_buf(struct tty_struct *tty, const unsigned char *c
 }
 
 static int unipi_tty_receive_buf2(struct tty_struct *tty, const unsigned char *cp,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 			      char *fp, int count)
+#else
+			      const char *fp, int count)
+#endif
 {
     int ret;
     int is_parmrk = I_PARMRK(tty);

--- a/modules/unipi/src/unipi_tty.c
+++ b/modules/unipi/src/unipi_tty.c
@@ -990,7 +990,9 @@ static long unipi_tty_compat_ioctl(struct tty_struct *tty, struct file *file,
 #endif
 
 static struct tty_ldisc_ops unipi_tty_ops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
 	.magic           = TTY_LDISC_MAGIC,
+#endif
   	.owner 			 = THIS_MODULE,
 	.name            = "unipi_tty",
 	.open            = unipi_tty_open,
@@ -1095,7 +1097,9 @@ int __init unipi_tty_init(void)
 
     memset(&unipi_tty_ldisc, 0, sizeof(unipi_tty_ldisc));
     n_tty_inherit_ops(&unipi_tty_ldisc);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
     unipi_tty_ldisc.magic           = TTY_LDISC_MAGIC;
+#endif
     unipi_tty_ldisc.name            = "unipi_tty";
     unipi_tty_ldisc.owner           = THIS_MODULE;
 


### PR DESCRIPTION
We use these patches in [balenaOS](https://github.com/balena-os/balena-raspberrypi/blob/master/layers/meta-balena-raspberrypi/recipes-kernel/unipi-kernel-modules/unipi-kernel-modules.bb) for building unipi-kernel-modules with kernel 5.15.92

Would be great if we could have these patches available from upstream